### PR TITLE
misc typo cleanup

### DIFF
--- a/Instructions/10992A_LAB_AK_02.md
+++ b/Instructions/10992A_LAB_AK_02.md
@@ -31,7 +31,7 @@
 4.   Click the  **Action** menu, and then on the menu, click **Create VHD**.
 5.   In the  **Create and Attach Virtual Hard Disk** dialog box, specify the following settings and then click **OK**:
   -   Location:  **D:\Mod02\Labfiles\LabDisk.vhdx**
-  -   Virtual hard disk size: **  1** **GB**
+  -   Virtual hard disk size: **1 GB**
   -   Virtual hard disk format:  **VHDX**
   -   Virtual hard disk type:  **Fixed size**
 6.   Right-click the newly created disk and, in the menu, click  **Detach VHD**.
@@ -41,7 +41,7 @@
 
 #### Task 3: Convert the .vhdx virtual disk to the .vhd format
   
-1.   On MIA-CL1, click  **Start**, in the list of apps, click the  **Windows PowerShell** folder, right-click **Windows PowerShell**, in the menu, click  **More**, and then click  **Run as** **administrator**.
+1.   On MIA-CL1, click  **Start**, in the list of apps, click the  **Windows PowerShell** folder, right-click **Windows PowerShell**, in the menu, click  **More**, and then click  **Run as administrator**.
 2.   At the  **Administrator: Windows PowerShell** prompt, type the following cmdlet, and then press Enter:
 
   ```
@@ -121,18 +121,18 @@
 4.   When asked whether to save or run the Docker Toolbox executable file, click  **Run**. This downloads the Docker Toolbox executable file and starts the Docker Toolbox Setup Wizard.
 5.   If prompted by User Account Control, click  **Yes**. 
 6.   On the  **Welcome to the Docker Toolbox Setup Wizard** page, clear the **Help Docker improve Toolbox** checkbox and click **Next**.
-7.   On the  **Select** **Destination** **Location** page, click **Next**.
-8.   On the  **Select Components** page, clear the **Kinematic for Windows (Alpha)** check box, and then click **Next**.
-9.   On the  **Select** **Additional** **Tasks** page, accept the default selection, and then click **Next**.
-10.   On the  **Ready to** **Install** page, click **Install**.
+7.   On the  **Select Destination** **Location** page, click **Next**.
+8.   On the  **Select Components** page, clear the **Kitematic for Windows (Alpha)** check box, and then click **Next**.
+9.   On the  **Select Additional Tasks** page, accept the default selection, and then click **Next**.
+10.   On the  **Ready to Install** page, click **Install**.
 11.   When asked by the  **Windows Security** dialog box whether to install a software device, click **Don't Install**.
 12.   On the  **Completing the Docker Toolbox Setup Wizard** page, clear the **View Shortcuts in File Explorer** check box and click **Finish**. 
 
 
 #### Task 2: Create a Docker host in a Hyper-V virtual machine by using Docker Machine
   
-1.   On MIA-CL1, click the Start button, type "cmd", right-click Command Prompt in the results returned, and then click Run as Administrator.
-2.   In the  **Administrator: Command** **Prompt** window **,** type the following command, and then press Enter.
+1.   On MIA-CL1, click the Start button, type "**cmd**", right-click Command Prompt in the results returned, and then click Run as Administrator.
+2.   In the  **Administrator: Command Prompt** window, type the following command, and then press Enter.
 
   ```
   docker-machine create --driver hyperv --hyperv-virtual-switch "Microsoft Hyper-V Network Adapter - Virtual Switch" localdockervm
@@ -168,27 +168,27 @@
 7.   On the  **Docker Machine for Azure** page, click **Accept**.
 8.   Switch back to the  **Administrator: Command Prompt** window, and then monitor the progress of provisioning the Azure virtual machine.
 9.   Wait for the new Docker Azure VM to be provisioned. 
-10.   In the  **Administrator: Command** **Prompt window,** type the following command, and press then Enter.
+10.   In the  **Administrator: Command Prompt** window, type the following command, and press then Enter.
 
   ```
   docker-machine ls
   ```
 
 11.   Verify that the output includes both the Hyper-V virtual machine and the Azure VM. 
-12.   In the  **Administrator: Command** **Prompt** window, type the following command, and then press Enter.
+12.   In the  **Administrator: Command Prompt** window, type the following command, and then press Enter.
 
   ```
   docker-machine env azuredockervm
   ```
 
-  If you receive an error checking the TLS connection, in the  **Administrator: Command** **Prompt window,** type the following command, press Enter, and, when prompted, type **y** to regenerate the TLS certificates.
+  If you receive an error checking the TLS connection, in the  **Administrator: Command Prompt** window, type the following command, press Enter, and, when prompted, type **y** to regenerate the TLS certificates.
 
   ```
   docker-machine regenerate-certs azuredockervm
   ```
 
 13.   Review the output returned by the  **docker-machine env** command.
-14.   In the  **Administrator: Command** **Prompt** window, type the following command, and then press Enter.
+14.   In the  **Administrator: Command Prompt** window, type the following command, and then press Enter.
 
   ```
   @FOR /f "tokens=*" %i IN ('docker-machine env azuredockervm') DO @%i
@@ -198,8 +198,8 @@
 #### Task 4: Run a container in a Docker host running in a Hyper-V virtual machine
   
 1.   On  **MIA-CL1**, in the  **Server Manager** window click **Tools**. 
-2.   On the  **Tools** menu, click **Hyper-V** **Manager**.
-3.   In the  **Hyper-V** **Manager** window, in the list of virtual machines, right-click **localdockervm**, and then click  **Connect**.
+2.   On the  **Tools** menu, click **Hyper-V Manager**.
+3.   In the  **Hyper-V Manager** window, in the list of virtual machines, right-click **localdockervm**, and then click  **Connect**.
 4.   At the command prompt in the console of the  **localdockervm** virtual machine, type the following command, and then press Enter.
 
   ```
@@ -338,10 +338,10 @@
   
 1.   In the Azure portal, in the  **hub** menu, click **Resource groups**.
 2.   In the  **Resource groups** blade, click **DockerRegistryRG**.
-3.   In the  **DockerRegistryRG** blade, click **Delete**.
+3.   In the  **DockerRegistryRG** blade, click **Delete resource group**.
 4.   In the  **Are you sure you want to delete "DockerRegistryRG"** blade, in the **TYPE THE RESOURCE GROUP NAME** box, type the name of the resource group, and then click **Delete**.
 5.   In the  **Resource groups** blade, click **docker-machine**.
-6.   In the  **docker-machine** blade, click **Delete**.
+6.   In the  **docker-machine** blade, click **Delete resource group**.
 7.   In the  **Are you sure you want to delete "docker-machine"** blade, in the **TYPE THE RESOURCE GROUP NAME** box, type the name of the resource group, and then click **Delete**.
 8.   Close all open windows.
 


### PR DESCRIPTION
"Ki**t**ematic", not "Ki**n**ematic" typo; the button to delete RGs now says **"Delete resource group"** (Not just **"Delete"**); and cleaned up some extra spaces in the bold commands.